### PR TITLE
add variables for client output buffer limits

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,6 +96,10 @@ redis_auto_aof_rewrite_percentage: "100"
 redis_auto_aof_rewrite_min_size: "64mb"
 redis_notify_keyspace_events: '""'
 
+redis_client_output_buffer_limit_normal: 0 0 0
+redis_client_output_buffer_limit_slave: 256mb 64mb 60
+redis_client_output_buffer_limit_pubsub: 32mb 8mb 60
+
 ## Redis sentinel configs
 # Set this to true on a host to configure it as a Sentinel
 redis_sentinel: false

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -92,8 +92,8 @@ set-max-intset-entries 512
 zset-max-ziplist-entries 128
 zset-max-ziplist-value 64
 activerehashing yes
-client-output-buffer-limit normal 0 0 0
-client-output-buffer-limit slave 256mb 64mb 60
-client-output-buffer-limit pubsub 32mb 8mb 60
+client-output-buffer-limit normal {{ redis_client_output_buffer_limit_normal }}
+client-output-buffer-limit slave {{ redis_client_output_buffer_limit_slave }}
+client-output-buffer-limit pubsub {{ redis_client_output_buffer_limit_pubsub }}
 hz 10
 aof-rewrite-incremental-fsync yes


### PR DESCRIPTION
This is the same work represented on the upstream project here: https://github.com/DavidWittman/ansible-redis/pull/198