### PR TITLE
Don't overwrite sentinel config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,6 +110,7 @@ redis_client_output_buffer_limit_pubsub: 32mb 8mb 60
 ## Redis sentinel configs
 # Set this to true on a host to configure it as a Sentinel
 redis_sentinel: false
+redis_sentinel_overwrite_config: false
 redis_sentinel_dir: /var/lib/redis/sentinel_{{ redis_sentinel_port }}
 redis_sentinel_bind: 0.0.0.0
 redis_sentinel_port: 26379

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -107,6 +107,7 @@
     dest: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf
     owner: "{{ redis_user }}"
     mode: 0640
+    force: "{{ redis_sentinel_overwrite_config }}"  # will only write the config if the file doesn't exist
   notify: "restart sentinel {{ redis_sentinel_port }}"
 
 - name: add sentinel init config file


### PR DESCRIPTION
We don't want this role to overwrite sentinel config and
restart the sentinel hosts, if the config already exists.
This behaviour is configurable through the redis_sentinel_overwrite_config
config option.